### PR TITLE
Fix password encoding missmatch

### DIFF
--- a/auth_handler.go
+++ b/auth_handler.go
@@ -247,7 +247,7 @@ func (a AuthHandler) oauth2Auth(origReq *http.Request) (AccessTokenResponse, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		if resp.StatusCode == 401 || resp.StatusCode == 403 {
-			return AccessTokenResponse{}, fmt.Errorf("Unauthorized on uaa")
+			return AccessTokenResponse{}, fmt.Errorf("%d: Unauthorized on uaa", resp.StatusCode)
 		}
 		b, _ := ioutil.ReadAll(resp.Body)
 		return AccessTokenResponse{}, fmt.Errorf("from oauth server %d: %s", resp.StatusCode, string(b))

--- a/login_page.go
+++ b/login_page.go
@@ -2,7 +2,8 @@ package aggregadantur
 
 import "fmt"
 
-const DefaultLoginTemplate = `<html>
+const DefaultLoginTemplate = `<!DOCTYPE html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Login</title>
@@ -28,7 +29,7 @@ const DefaultLoginTemplate = `<html>
           background-image: -webkit-gradient(linear, 0 0, 0 100%%, from(#ffffff), to(#e6e6e6));
           background-image: -webkit-linear-gradient(top, #ffffff, #e6e6e6);
           background-image: -o-linear-gradient(top, #ffffff, #e6e6e6);
-          background-image: linear-gradient(top, #ffffff, #e6e6e6);
+          background-image: linear-gradient(to top, #ffffff, #e6e6e6);
           background-repeat: repeat-x;
           filter: progid:dximagetransform.microsoft.gradient(startColorstr=#ffffff, endColorstr=#e6e6e6, GradientType=0);
           border-color: #e6e6e6 #e6e6e6 #e6e6e6;
@@ -85,7 +86,7 @@ const DefaultLoginTemplate = `<html>
           background-image: -webkit-gradient(linear, 0 0, 0 100%%, from(#6eb6de), to(#4a77d4));
           background-image: -webkit-linear-gradient(top, #6eb6de, #4a77d4);
           background-image: -o-linear-gradient(top, #6eb6de, #4a77d4);
-          background-image: linear-gradient(top, #6eb6de, #4a77d4);
+          background-image: linear-gradient(to top, #6eb6de, #4a77d4);
           background-repeat: repeat-x;
           filter: progid:dximagetransform.microsoft.gradient(startColorstr=#6eb6de, endColorstr=#4a77d4, GradientType=0);
           border: 1px solid #3762bc;

--- a/login_page.go
+++ b/login_page.go
@@ -4,6 +4,7 @@ import "fmt"
 
 const DefaultLoginTemplate = `<html>
 <head>
+  <meta charset="utf-8">
   <title>Login</title>
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <style>


### PR DESCRIPTION
This fix the cases where a field (mostly password) containing special characters (such as `ç`) were implicitly encoded as `windows-1252` (instead of `UTF-8`) in the form and, as such, not correctly transmitted to the UAA resulting in an authentication error.

The same credentials used in HTTP Authorization Basic were not subject to this bug.

Additionally, this make the login page HTML5 compliant.